### PR TITLE
Fix code formatting issues in UDP server tests

### DIFF
--- a/lib/tenbin_cache/logger.ex
+++ b/lib/tenbin_cache/logger.ex
@@ -164,7 +164,7 @@ defmodule TenbinCache.Logger do
 
   # Private functions
 
-  defp dns_logging_enabled?() do
+  defp dns_logging_enabled? do
     # First check Application environment (for tests)
     case Application.get_env(:tenbin_cache, :dns_query_logging) do
       nil ->
@@ -181,7 +181,7 @@ defmodule TenbinCache.Logger do
     end
   end
 
-  defp iso8601_timestamp() do
+  defp iso8601_timestamp do
     DateTime.utc_now()
     |> DateTime.to_iso8601()
   end

--- a/test/tenbin_cache/udp_server_test.exs
+++ b/test/tenbin_cache/udp_server_test.exs
@@ -180,7 +180,9 @@ defmodule TenbinCache.UDPServerTest do
     test "configures packet dumping when enabled in config" do
       # Ensure ConfigParser is running - restart if needed
       case Process.whereis(TenbinCache.ConfigParser) do
-        nil -> {:ok, _pid} = TenbinCache.ConfigParser.start_link([])
+        nil ->
+          {:ok, _pid} = TenbinCache.ConfigParser.start_link([])
+
         pid when is_pid(pid) ->
           if Process.alive?(pid) do
             :ok
@@ -216,7 +218,9 @@ defmodule TenbinCache.UDPServerTest do
     test "configures packet dumping as disabled when config is false" do
       # Ensure ConfigParser is running - restart if needed
       case Process.whereis(TenbinCache.ConfigParser) do
-        nil -> {:ok, _pid} = TenbinCache.ConfigParser.start_link([])
+        nil ->
+          {:ok, _pid} = TenbinCache.ConfigParser.start_link([])
+
         pid when is_pid(pid) ->
           if Process.alive?(pid) do
             :ok


### PR DESCRIPTION
## Summary

This PR fixes the remaining code formatting issues that are causing CI failures.

## Changes

- Apply proper Elixir formatting to case expressions in `test/tenbin_cache/udp_server_test.exs`
- Add required line breaks after `nil ->` clauses
- Ensure consistent formatting across test files

## Testing

- ✅ Local tests pass: All 54 tests passing
- ✅ Format check passes: `mix format --check-formatted` reports no issues
- 🔄 CI check: Awaiting workflow results

## Context

These formatting issues were introduced during the previous test fixes and need to be resolved to get CI passing on the main branch.